### PR TITLE
Added OpenAI summary for the currently opened URL

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -693,6 +693,7 @@
 		96EB6C4027DBEE9800A9D159 /* SearchGroupedItemsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96EB6C3F27DBEE9800A9D159 /* SearchGroupedItemsViewController.swift */; };
 		96EB6C4327DC205D00A9D159 /* SearchGroupedItemsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96EB6C4227DC205D00A9D159 /* SearchGroupedItemsViewModel.swift */; };
 		96F8DA49280452CA00E53239 /* GleanPlumbContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F8DA48280452CA00E53239 /* GleanPlumbContextProvider.swift */; };
+		9C17AA6829E600F80076423C /* SummarizeFeature in Frameworks */ = {isa = PBXBuildFile; productRef = 9C17AA6729E600F80076423C /* SummarizeFeature */; };
 		A83E5B1A1C1DA8BF0026D912 /* image.gif in Resources */ = {isa = PBXBuildFile; fileRef = A83E5B181C1DA8BF0026D912 /* image.gif */; };
 		A83E5B1B1C1DA8BF0026D912 /* image.png in Resources */ = {isa = PBXBuildFile; fileRef = A83E5B191C1DA8BF0026D912 /* image.png */; };
 		A83E5B1D1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83E5B1C1C1DA8D80026D912 /* UIPasteboardExtensionsTests.swift */; };
@@ -4133,6 +4134,7 @@
 		9BA0422985D5448896A3EC26 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = "uk.lproj/Default Browser.strings"; sourceTree = "<group>"; };
 		9BAB4C0A93050A8433505859 /* dsb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = dsb; path = dsb.lproj/AuthenticationManager.strings; sourceTree = "<group>"; };
 		9BCB46C0B4A2E1E8E41F84C2 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		9C17AA6629E600E20076423C /* SummarizeFeature */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = SummarizeFeature; sourceTree = "<group>"; };
 		9C214B508D4BCDCA6DE617D5 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9C2B4D879C3D4229E6AFF24D /* ast */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ast; path = ast.lproj/FindInPage.strings; sourceTree = "<group>"; };
 		9C394C648290198D6C3E1A10 /* pt-PT */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-PT"; path = "pt-PT.lproj/FindInPage.strings"; sourceTree = "<group>"; };
@@ -4142,6 +4144,7 @@
 		9C8043F3BB77DF533FF48412 /* gd */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = gd; path = gd.lproj/ClearPrivateData.strings; sourceTree = "<group>"; };
 		9C8B45CBA683ED6ED42E65C4 /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = id.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		9CBD4A5BA6812CB2D750FC54 /* kk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = kk; path = kk.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		9CD0E23329E615B400E27F27 /* OpenAIClient */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = OpenAIClient; sourceTree = "<group>"; };
 		9CE741DE985009A84C17055A /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/PrivateBrowsing.strings; sourceTree = "<group>"; };
 		9CFA43989ED93A183C8AF998 /* oc */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = oc; path = oc.lproj/FindInPage.strings; sourceTree = "<group>"; };
 		9D0D40298CF6F2B8A1BF375E /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/Storage.strings; sourceTree = "<group>"; };
@@ -5830,6 +5833,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5A70EF0E295DFCCF00790249 /* Common in Frameworks */,
+				9C17AA6829E600F80076423C /* SummarizeFeature in Frameworks */,
 				8A08EC6427EBDCAD00E119C7 /* AdServices.framework in Frameworks */,
 				8A08EC6227EBDCA400E119C7 /* iAd.framework in Frameworks */,
 				43BE580E278BABCF00491291 /* RustMozillaAppServices.framework in Frameworks */,
@@ -8840,6 +8844,8 @@
 		F84B21B51A090F8100AAB793 = {
 			isa = PBXGroup;
 			children = (
+				9CD0E23329E615B400E27F27 /* OpenAIClient */,
+				9C17AA6629E600E20076423C /* SummarizeFeature */,
 				962C6C39297054A700354BE8 /* Package.swift */,
 				962C6C3F2971F5D400354BE8 /* Dangerfile.swift */,
 				962C6C3B297054EC00354BE8 /* Sources */,
@@ -9607,6 +9613,7 @@
 				5A70EF0D295DFCCF00790249 /* Common */,
 				5A37861829A2C337006B3A34 /* Sentry */,
 				5A06135929D6052E008F3D38 /* TabDataStore */,
+				9C17AA6729E600F80076423C /* SummarizeFeature */,
 			);
 			productName = Client;
 			productReference = F84B21BE1A090F8100AAB793 /* Client.app */;
@@ -16950,6 +16957,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 435C85EE2788F4D00072B526 /* XCRemoteSwiftPackageReference "glean-swift" */;
 			productName = Glean;
+		};
+		9C17AA6729E600F80076423C /* SummarizeFeature */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SummarizeFeature;
 		};
 		D433852B27ABC8150069DD33 /* MappaMundi */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "882ac01eb7ef9e36d4467eb4b1151e74fcef85ab",
+        "version" : "0.9.1"
+      }
+    },
+    {
       "identity" : "dip",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/AliSoftware/Dip.git",
@@ -82,6 +91,15 @@
       }
     },
     {
+      "identity" : "openai-streaming-completions-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nate-parrott/openai-streaming-completions-swift",
+      "state" : {
+        "branch" : "main",
+        "revision" : "dc294e47cb6dab5113cdb9c6e5b7efdd7f56ca96"
+      }
+    },
+    {
       "identity" : "rust-components-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/rust-components-swift.git",
@@ -109,6 +127,78 @@
       }
     },
     {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "fc45e7b2cfece9dd80b5a45e6469ffe67fe67984",
+        "version" : "0.14.1"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "20b25ca0dd88ebfb9111ec937814ddc5a8880172",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
+        "version" : "1.0.4"
+      }
+    },
+    {
+      "identity" : "swift-composable-architecture",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-composable-architecture",
+      "state" : {
+        "branch" : "main",
+        "revision" : "4192a843ee427a93893c532012e23ca089eeb8a0"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "805c57f32a5934ee420f30ba129f00aa8c7575a1",
+        "version" : "0.10.0"
+      }
+    },
+    {
+      "identity" : "swift-dependencies",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-dependencies",
+      "state" : {
+        "branch" : "main",
+        "revision" : "0f34848e741315119703b1990e5c962929ed5dff"
+      }
+    },
+    {
+      "identity" : "swift-identified-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-identified-collections",
+      "state" : {
+        "revision" : "f52eee28bdc6065aa2f8424067e6f04c74bda6e6",
+        "version" : "0.7.1"
+      }
+    },
+    {
+      "identity" : "swiftui-navigation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swiftui-navigation",
+      "state" : {
+        "revision" : "47dd574b900ba5ba679f56ea00d4d282fc7305a6",
+        "version" : "0.7.1"
+      }
+    },
+    {
       "identity" : "swiftybeaver",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SwiftyBeaver/SwiftyBeaver.git",
@@ -133,6 +223,15 @@
       "state" : {
         "revision" : "68f2d813320c9fda2fb4aee4548c64293500200a",
         "version" : "2.0.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "ab8c9f45843694dd16be4297e6d44c0634fd9913",
+        "version" : "0.8.4"
       }
     }
   ],

--- a/Client/Application/AccessibilityIdentifiers.swift
+++ b/Client/Application/AccessibilityIdentifiers.swift
@@ -15,6 +15,7 @@ public struct AccessibilityIdentifiers {
     struct Toolbar {
         static let settingsMenuButton = "TabToolbar.menuButton"
         static let homeButton = "TabToolbar.homeButton"
+        static let summarizeButton = "TabToolbar.summarizeButton"
         static let trackingProtection = "TabLocationView.trackingProtectionButton"
         static let readerModeButton = "TabLocationView.readerModeButton"
         static let reloadButton = "TabLocationView.reloadButton"

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+TabToolbarDelegate.swift
@@ -17,6 +17,10 @@ extension BrowserViewController: TabToolbarDelegate, PhotonActionSheetProtocol {
         TelemetryWrapper.recordEvent(category: .action, method: .tap, object: .home)
     }
 
+    func tabToolbarDidPressSummarize(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
+        showSummarizeOverlay(for: tabManager.selectedTab?.url)
+    }
+    
     func tabToolbarDidPressLibrary(_ tabToolbar: TabToolbarProtocol, button: UIButton) {
     }
 

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -30,6 +30,10 @@ class DismissableNavigationViewController: UINavigationController, OnViewDismiss
 }
 
 extension BrowserViewController: URLBarDelegate {
+    func showSummarizeOverlay(for url: URL?) {
+        
+    }
+    
     func showTabTray(withFocusOnUnselectedTab tabToFocus: Tab? = nil,
                      focusedSegment: TabTrayViewModel.Segment? = nil) {
         updateFindInPageVisibility(visible: false)

--- a/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
+++ b/Client/Frontend/Browser/BrowserViewController/BrowserViewController+URLBarDelegate.swift
@@ -7,6 +7,7 @@ import Storage
 import Telemetry
 import Glean
 import Common
+import SummarizeFeature
 
 protocol OnViewDismissable: AnyObject {
     var onViewDismissed: (() -> Void)? { get set }
@@ -31,7 +32,17 @@ class DismissableNavigationViewController: UINavigationController, OnViewDismiss
 
 extension BrowserViewController: URLBarDelegate {
     func showSummarizeOverlay(for url: URL?) {
+        guard let url = url else { return }
+                
+        let summarizeViewController = SummarizeViewController(url: url)
         
+        let navigationController = ThemedDefaultNavigationController(rootViewController: summarizeViewController)
+        navigationController.presentationController?.delegate = summarizeViewController
+        if #available(iOS 15.0, *) {
+            navigationController.sheetPresentationController?.detents = [.medium()]
+        }
+
+        self.present(navigationController, animated: true, completion: nil)
     }
     
     func showTabTray(withFocusOnUnselectedTab tabToFocus: Tab? = nil,

--- a/Client/Frontend/Strings.swift
+++ b/Client/Frontend/Strings.swift
@@ -3025,6 +3025,11 @@ extension String {
                 tableName: nil,
                 value: "Home",
                 comment: "Accessibility label for the Home button on the toolbar. Pressing this button brings the user to the home page.")
+            public static let SummarizeMenuButtonAccessibilityLabel = MZLocalizedString(
+                "Menu.Toolbar.Summarize.AccessibilityLabel.v99",
+                tableName: nil,
+                value: "Summarize",
+                comment: "Accessibility label for the Summarize button on the toolbar. Pressing this button generates summary of the currently opened page.")
             public static let BookmarksButtonAccessibilityLabel = MZLocalizedString(
                 "Menu.Toolbar.Bookmarks.AccessibilityLabel.v99",
                 tableName: nil,

--- a/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabToolbar.swift
@@ -17,6 +17,7 @@ class TabToolbar: UIView {
     let forwardButton = ToolbarButton()
     let backButton = ToolbarButton()
     let multiStateButton = ToolbarButton()
+    let summarizeButton = ToolbarButton()
     let actionButtons: [NotificationThemeable & UIButton]
 
     private let privateModeBadge = BadgeWithBackdrop(imageName: ImageIdentifiers.privateModeBadge,
@@ -30,7 +31,7 @@ class TabToolbar: UIView {
 
     // MARK: - Initializers
     private override init(frame: CGRect) {
-        actionButtons = [backButton, forwardButton, multiStateButton, addNewTabButton, tabsButton, appMenuButton]
+        actionButtons = [backButton, forwardButton, multiStateButton, summarizeButton, addNewTabButton, tabsButton, appMenuButton]
         super.init(frame: frame)
         setupAccessibility()
 

--- a/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
+++ b/Client/Frontend/Toolbar+URLBar/TabToolbarHelper.swift
@@ -16,6 +16,7 @@ protocol TabToolbarProtocol: AnyObject {
     var forwardButton: ToolbarButton { get }
     var backButton: ToolbarButton { get }
     var multiStateButton: ToolbarButton { get }
+    var summarizeButton: ToolbarButton { get }
     var actionButtons: [NotificationThemeable & UIButton] { get }
 
     func updateBackStatus(_ canGoBack: Bool)
@@ -36,6 +37,7 @@ protocol TabToolbarDelegate: AnyObject {
     func tabToolbarDidLongPressReload(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressStop(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressHome(_ tabToolbar: TabToolbarProtocol, button: UIButton)
+    func tabToolbarDidPressSummarize(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressMenu(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressBookmarks(_ tabToolbar: TabToolbarProtocol, button: UIButton)
     func tabToolbarDidPressTabs(_ tabToolbar: TabToolbarProtocol, button: UIButton)
@@ -137,6 +139,12 @@ open class TabToolbarHelper: NSObject {
         toolbar.homeButton.accessibilityLabel = .AppMenu.Toolbar.HomeMenuButtonAccessibilityLabel
         toolbar.homeButton.addTarget(self, action: #selector(didClickHome), for: .touchUpInside)
         toolbar.homeButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.homeButton
+        
+        toolbar.summarizeButton.contentMode = .center
+        toolbar.summarizeButton.setImage(UIImage.templateSystemImageNamed("doc.text"), for: .normal)
+        toolbar.summarizeButton.accessibilityLabel = .AppMenu.Toolbar.SummarizeMenuButtonAccessibilityLabel
+        toolbar.summarizeButton.addTarget(self, action: #selector(didClickSummarize), for: .touchUpInside)
+        toolbar.summarizeButton.accessibilityIdentifier = AccessibilityIdentifiers.Toolbar.summarizeButton
 
         toolbar.bookmarksButton.contentMode = .center
         toolbar.bookmarksButton.setImage(UIImage.templateImageNamed(ImageIdentifiers.bookmarks), for: .normal)
@@ -186,6 +194,10 @@ open class TabToolbarHelper: NSObject {
 
     func didClickHome() {
         toolbar.tabToolbarDelegate?.tabToolbarDidPressHome(toolbar, button: toolbar.appMenuButton)
+    }
+    
+    func didClickSummarize() {
+        toolbar.tabToolbarDelegate?.tabToolbarDidPressSummarize(toolbar, button: toolbar.summarizeButton)
     }
 
     func didClickLibrary() {

--- a/Client/Frontend/Toolbar+URLBar/URLBarView.swift
+++ b/Client/Frontend/Toolbar+URLBar/URLBarView.swift
@@ -180,6 +180,7 @@ class URLBarView: UIView, URLBarViewProtocol, AlphaDimmable, TopBottomInterchang
     var appMenuButton = ToolbarButton()
     var bookmarksButton = ToolbarButton()
     var homeButton = ToolbarButton()
+    var summarizeButton = ToolbarButton()
     var addNewTabButton = ToolbarButton()
     var forwardButton = ToolbarButton()
     var multiStateButton = ToolbarButton()

--- a/OpenAIClient/.gitignore
+++ b/OpenAIClient/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/OpenAIClient/Package.resolved
+++ b/OpenAIClient/Package.resolved
@@ -1,0 +1,104 @@
+{
+  "pins" : [
+    {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "882ac01eb7ef9e36d4467eb4b1151e74fcef85ab",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "openai-streaming-completions-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nate-parrott/openai-streaming-completions-swift",
+      "state" : {
+        "branch" : "main",
+        "revision" : "dc294e47cb6dab5113cdb9c6e5b7efdd7f56ca96"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "fc45e7b2cfece9dd80b5a45e6469ffe67fe67984",
+        "version" : "0.14.1"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "20b25ca0dd88ebfb9111ec937814ddc5a8880172",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
+        "version" : "1.0.4"
+      }
+    },
+    {
+      "identity" : "swift-composable-architecture",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-composable-architecture",
+      "state" : {
+        "branch" : "main",
+        "revision" : "4192a843ee427a93893c532012e23ca089eeb8a0"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "805c57f32a5934ee420f30ba129f00aa8c7575a1",
+        "version" : "0.10.0"
+      }
+    },
+    {
+      "identity" : "swift-dependencies",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-dependencies",
+      "state" : {
+        "branch" : "main",
+        "revision" : "0f34848e741315119703b1990e5c962929ed5dff"
+      }
+    },
+    {
+      "identity" : "swift-identified-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-identified-collections",
+      "state" : {
+        "revision" : "f52eee28bdc6065aa2f8424067e6f04c74bda6e6",
+        "version" : "0.7.1"
+      }
+    },
+    {
+      "identity" : "swiftui-navigation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swiftui-navigation",
+      "state" : {
+        "revision" : "47dd574b900ba5ba679f56ea00d4d282fc7305a6",
+        "version" : "0.7.1"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "ab8c9f45843694dd16be4297e6d44c0634fd9913",
+        "version" : "0.8.4"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/OpenAIClient/Package.swift
+++ b/OpenAIClient/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version: 5.7
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "OpenAIClient",
+    platforms: [
+        .iOS(.v13),
+    ],
+    products: [
+        .library(name: "OpenAIClient", targets: ["OpenAIClient"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/nate-parrott/openai-streaming-completions-swift", branch: "main"),
+        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", branch: "main"),
+        .package(url: "https://github.com/pointfreeco/swift-dependencies", branch: "main"),
+    ],
+    targets: [
+        .target(
+            name: "OpenAIClient",
+            dependencies: [
+                .product(name: "OpenAIStreamingCompletions", package: "openai-streaming-completions-swift"),
+                .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
+                .product(name: "Dependencies", package: "swift-dependencies"),
+            ]
+        ),
+        .testTarget(
+            name: "OpenAIClientTests",
+            dependencies: ["OpenAIClient"]
+        ),
+    ]
+)

--- a/OpenAIClient/README.md
+++ b/OpenAIClient/README.md
@@ -1,0 +1,3 @@
+# OpenAIClient
+
+A description of this package.

--- a/OpenAIClient/Sources/OpenAIClient/OpenAIClient.swift
+++ b/OpenAIClient/Sources/OpenAIClient/OpenAIClient.swift
@@ -1,0 +1,30 @@
+//
+//  OpenAIClient.swift
+//
+
+import Foundation
+import Dependencies
+import XCTestDynamicOverlay
+import OpenAIStreamingCompletions
+
+public extension DependencyValues {
+    var openAIClient: OpenAIClient {
+        get { self[OpenAIClient.self] }
+        set { self[OpenAIClient.self] = newValue }
+    }
+}
+
+public struct OpenAIClient {
+    public var summaryForUrl: @Sendable (_ url: URL) -> StreamingCompletion?
+}
+
+extension OpenAIClient: TestDependencyKey {
+    public static var testValue = Self(
+        summaryForUrl: unimplemented("\(Self.self).summaryForUrl")
+    )
+    
+//    static let previewValue = Self(
+//        createEdit: unimplemented("\(Self.self).createEdit"),
+//        createCompletion: unimplemented("\(Self.self).createCompletion")
+//    )
+}

--- a/OpenAIClient/Sources/OpenAIClient/OpenAIClientLive.swift
+++ b/OpenAIClient/Sources/OpenAIClient/OpenAIClientLive.swift
@@ -1,0 +1,22 @@
+//
+//  OpenAIClientLive.swift
+//
+
+import Foundation
+import Dependencies
+import OpenAIStreamingCompletions
+
+fileprivate var apiKey: String {
+    // You can use raw string for testing purposes, but it's better to provide API_KEY from env vars.
+    ProcessInfo.processInfo.environment["OPENAI_API_KEY"] ?? ""
+}
+fileprivate let openAI = OpenAIAPI(apiKey: apiKey)
+
+extension OpenAIClient: DependencyKey {
+    public static let liveValue = OpenAIClient(
+        summaryForUrl: { url in
+            let prompt = "tldr \(url.absoluteString)"
+            return try? openAI.completeStreaming(.init(prompt: prompt, max_tokens: 512))
+        }
+    )
+}

--- a/OpenAIClient/Tests/OpenAIClientTests/OpenAIClientTests.swift
+++ b/OpenAIClient/Tests/OpenAIClientTests/OpenAIClientTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+import Dependencies
+import XCTestDynamicOverlay
+@testable import OpenAIClient
+
+final class OpenAIClientTests: XCTestCase {
+    private let testURL: URL = URL(string: "https://www.pumabrowser.com")!
+
+    @Dependency(\.openAIClient) var openAIClient
+    
+    func testShouldInitiallyChangeStatusToLoadingWhenRequestSummary() throws {
+        withDependencies {
+            $0.openAIClient = .liveValue
+        } operation: {
+            let summary = openAIClient.summaryForUrl(testURL)
+            
+            XCTAssertEqual(summary?.status, .loading)
+        }
+    }
+}

--- a/Shared/Extensions/UIImageExtensions.swift
+++ b/Shared/Extensions/UIImageExtensions.swift
@@ -49,6 +49,10 @@ extension UIImage {
     public static func templateImageNamed(_ name: String) -> UIImage? {
         return UIImage(named: name)?.withRenderingMode(.alwaysTemplate)
     }
+    
+    public static func templateSystemImageNamed(_ name: String) -> UIImage? {
+        return UIImage(systemName: name)?.withRenderingMode(.alwaysTemplate)
+    }
 
     // Uses compositor blending to apply color to an image.
     public func tinted(withColor: UIColor) -> UIImage {

--- a/Shared/en-US.lproj/Localizable.strings
+++ b/Shared/en-US.lproj/Localizable.strings
@@ -832,6 +832,9 @@
 /* Accessibility label for the Home button on the toolbar. Pressing this button brings the user to the home page. */
 "Menu.Toolbar.Home.AccessibilityLabel.v99" = "Home";
 
+/* Accessibility label for the Summarize button on the toolbar. Pressing this button generates summary of the currently opened page. */
+"Menu.Toolbar.Summarize.AccessibilityLabel.v99" = "Summarize";
+
 /* String to let users know the site verifier, where the placeholder represents the SSL certificate signer. */
 "Menu.TrackingProtection.Details.Verifier" = "Verified by %@";
 

--- a/SummarizeFeature/.gitignore
+++ b/SummarizeFeature/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/SummarizeFeature/Package.swift
+++ b/SummarizeFeature/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version: 5.6
+
+import PackageDescription
+
+let package = Package(
+    name: "SummarizeFeature",
+    platforms: [
+        .iOS(.v13),
+    ],
+    products: [
+        .library(name: "SummarizeFeature", targets: ["SummarizeFeature"]),
+    ],
+    dependencies: [
+        Package.Dependency.package(path: "../OpenAIClient"),
+        .package(url: "https://github.com/pointfreeco/swift-composable-architecture", branch: "main"),
+        .package(url: "https://github.com/pointfreeco/swift-dependencies", branch: "main"),
+    ],
+    targets: [
+        .target(
+            name: "SummarizeFeature",
+            dependencies: [
+                "OpenAIClient",
+                .product(name: "ComposableArchitecture", package: "swift-composable-architecture"),
+                .product(name: "Dependencies", package: "swift-dependencies"),
+            ]
+        ),
+        .testTarget(
+            name: "SummarizeFeatureTests",
+            dependencies: ["SummarizeFeature"]
+        ),
+    ]
+)

--- a/SummarizeFeature/README.md
+++ b/SummarizeFeature/README.md
@@ -1,0 +1,3 @@
+# SummarizeFeature
+
+A description of this package.

--- a/SummarizeFeature/Sources/SummarizeFeature/CompletionView.swift
+++ b/SummarizeFeature/Sources/SummarizeFeature/CompletionView.swift
@@ -1,0 +1,38 @@
+//
+//  CompletionView.swift
+//
+
+import SwiftUI
+import ComposableArchitecture
+import OpenAIStreamingCompletions
+
+struct CompletionView: View {
+    @ObservedObject private var completion: StreamingCompletion
+    
+    public init(completion: StreamingCompletion) {
+        self.completion = completion
+    }
+    
+    var body: some View {
+        VStack {
+            ScrollView {
+                Text("\(completion.text)")
+                    .multilineTextAlignment(.leading)
+                    .lineLimit(nil)
+            }
+            Divider()
+            Text(completion.status.text)
+        }
+        .padding(.horizontal)
+    }
+}
+
+extension StreamingCompletion.Status {
+    var text: String {
+        switch self {
+        case .error: return "Error: something went wrong"
+        case .complete: return "Completed"
+        case .loading: return "Loading..."
+        }
+    }
+}

--- a/SummarizeFeature/Sources/SummarizeFeature/Extensions/NavigationTitleViewModifier.swift
+++ b/SummarizeFeature/Sources/SummarizeFeature/Extensions/NavigationTitleViewModifier.swift
@@ -1,0 +1,21 @@
+//
+//  NavigationTitleViewModifier.swift
+//
+
+import SwiftUI
+
+fileprivate struct NavigationTitleViewModifier<S: StringProtocol>: ViewModifier {
+    var title: S
+    
+    func body(content: Content) -> some View {
+        content.navigationBarTitle(title)
+    }
+}
+
+extension View {
+    @_disfavoredOverload
+    @ViewBuilder
+    public func navigationTitle<S>(_ title: S) -> some View where S : StringProtocol {
+        self.modifier(NavigationTitleViewModifier(title: title))
+    }
+}

--- a/SummarizeFeature/Sources/SummarizeFeature/SummarizeReducer.swift
+++ b/SummarizeFeature/Sources/SummarizeFeature/SummarizeReducer.swift
@@ -1,0 +1,47 @@
+//
+//  SummarizeReducer.swift
+//
+
+import Foundation
+import Dependencies
+import OpenAIClient
+import OpenAIStreamingCompletions
+import ComposableArchitecture
+
+struct SummarizeReducer: ReducerProtocol {
+    private enum OpenAICommandID {}
+    
+    struct State: Equatable {
+        var url: URL
+        var completion: StreamingCompletion? = nil
+    }
+
+    enum Action: Equatable {
+        case onAppear
+        case onDisappear
+        
+        case invokeCommand
+    }
+    
+    @Dependency(\.openAIClient) var openAIClient
+    
+    func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+        switch action {
+        case .onAppear:
+            return .task { .invokeCommand }
+            
+        case .onDisappear:
+            return .cancel(id: OpenAICommandID.self)
+            
+        case .invokeCommand:
+            state.completion = openAIClient.summaryForUrl(state.url)
+            return .none
+        }
+    }
+}
+
+extension StreamingCompletion: Equatable {
+    public static func == (lhs: OpenAIStreamingCompletions.StreamingCompletion, rhs: OpenAIStreamingCompletions.StreamingCompletion) -> Bool {
+        lhs.text == rhs.text && lhs.status == rhs.status
+    }
+}

--- a/SummarizeFeature/Sources/SummarizeFeature/SummarizeView.swift
+++ b/SummarizeFeature/Sources/SummarizeFeature/SummarizeView.swift
@@ -1,0 +1,37 @@
+//
+//  SummarizeView.swift
+//
+
+import SwiftUI
+import OpenAIStreamingCompletions
+import ComposableArchitecture
+
+public struct SummarizeView: View {
+    private let store: StoreOf<SummarizeReducer>
+    @ObservedObject var viewStore: ViewStoreOf<SummarizeReducer>
+    
+    public init(url: URL) {
+        store = Store(
+            initialState: .init(url: url),
+            reducer: SummarizeReducer()
+        )
+        viewStore = ViewStore(store)
+    }
+    
+    public var body: some View {
+        VStack {
+            if let completion = viewStore.completion {
+                CompletionView(completion: completion)
+            }
+        }
+        .navigationTitle("Summary")
+        .onAppear { viewStore.send(.onAppear) }
+        .onDisappear { viewStore.send(.onDisappear) }
+    }
+}
+
+struct SummarizeView_Previews: PreviewProvider {
+    static var previews: some View {
+        SummarizeView(url: URL(string: "https://www.pumabrowser.com")!)
+    }
+}

--- a/SummarizeFeature/Sources/SummarizeFeature/SummarizeViewController.swift
+++ b/SummarizeFeature/Sources/SummarizeFeature/SummarizeViewController.swift
@@ -1,0 +1,39 @@
+//
+//  SummarizeViewController.swift
+//
+
+import UIKit
+import SwiftUI
+
+public class SummarizeViewController: UIHostingController<SummarizeView> {
+    public init(url: URL) {
+        super.init(rootView: SummarizeView(url: url))
+    }
+    
+    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - Adaptive Delegate
+extension SummarizeViewController: UIAdaptivePresentationControllerDelegate {
+    // Returning None here, for the iPhone makes sure that the Popover is actually presented as a
+    // Popover and not as a full-screen modal, which is the default on compact device classes.
+    public func adaptivePresentationStyle(
+        for controller: UIPresentationController,
+        traitCollection: UITraitCollection
+    ) -> UIModalPresentationStyle {
+        shouldUseiPadSetup(traitCollection: traitCollection) ? .overFullScreen : .none
+    }
+}
+
+extension UIViewController {
+    func shouldUseiPadSetup(traitCollection: UITraitCollection? = nil) -> Bool {
+        let trait = traitCollection == nil ? self.traitCollection : traitCollection
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            return trait!.horizontalSizeClass != .compact
+        }
+        
+        return false
+    }
+}

--- a/SummarizeFeature/Tests/SummarizeFeatureTests/SummarizeFeatureTests.swift
+++ b/SummarizeFeature/Tests/SummarizeFeatureTests/SummarizeFeatureTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+import Dependencies
+import XCTestDynamicOverlay
+import ComposableArchitecture
+
+@testable import SummarizeFeature
+
+@MainActor
+final class SummarizeFeatureTests: XCTestCase {
+    private let testURL: URL = URL(string: "https://www.pumabrowser.com")!
+    
+    func testShouldInitWithNilCompletionState() async throws {
+        let store = TestStore(
+            initialState: SummarizeReducer.State(url: testURL),
+            reducer: SummarizeReducer()
+        )
+        store.dependencies.openAIClient.summaryForUrl = { _ in nil }
+        
+        XCTAssertEqual(store.state.completion, nil)
+    }
+    
+    func testShouldInvokeOnAppear() async throws {
+        let store = TestStore(
+            initialState: SummarizeReducer.State(url: testURL),
+            reducer: SummarizeReducer()
+        )
+        store.dependencies.openAIClient.summaryForUrl = { _ in nil }
+        await store.send(.onAppear)
+        await store.receive(.invokeCommand)
+    }
+}


### PR DESCRIPTION
- added `OpenAIClient` module which exposes OpenAI API (which wraps 3rd party library)
- added `SummarizeFeature` module, which holds everything needed to show the summary
- added Summary button in main app as an entry point to the `SummarizeFeature`
- few super-simple unit-tests (not much to test there). 

__**NOTES**__:
- I chose to use TCA because it is incredibly ergonomic and I am accustomed to it. That doesn't mean that It can't also be implemented with MVVM, MVC, or any other architecture.
- Before you'll be able to use the summarize feature, you'll need either to provide it in env.vars or through fallback directly in the `OpenAIClientLive`

There's plenty of improvements I would do such as:
- I would write my own implementation of SSE, to have more control over what happens there (since there's no 3rd party library properly working and tested at the moment)
- add proper/better error handling (`OpenAIStreamingCompletions` doesn't expose much)
- work on a better UI with bells and whistles, like indefinite progress bar, restart summary etc.
- add proper localisation 
- I can proceed with this for quite a while, but that's enough for the moment :) 

Short demo:

https://user-images.githubusercontent.com/20221382/231553792-dfb0a9d7-01dc-4a3b-a44d-3c298c77a6b3.mov


